### PR TITLE
Data-block-fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ terraform.rc
 
 # Artifacts
 *.zip
+tfplan

--- a/modules/function-app/function-app.tf
+++ b/modules/function-app/function-app.tf
@@ -21,7 +21,7 @@ resource "azurerm_windows_function_app" "function_app" {
     "WEBSITE_RUN_FROM_PACKAGE"                    = "1",
     "FUNCTIONS_WORKER_RUNTIME"                    = "node",
     "AzureWebJobsDisableHomepage"                 = "true",
-    "WEBSITE_NODE_DEFAULT_VERSION"                = "~18",
+    "WEBSITE_NODE_DEFAULT_VERSION"                = "~20",
     "EventHubConnection__credential"              = "managedidentity",
     "EventHubConnection__fullyQualifiedNamespace" = format("%s.servicebus.windows.net", var.event_hub_namespace_name),
     "DD_API_KEY"                                  = var.datadog_api_key,

--- a/modules/function-app/function-app.tf
+++ b/modules/function-app/function-app.tf
@@ -129,7 +129,8 @@ locals {
 resource "null_resource" "function_app_publish" {
   depends_on = [local.publish_code_command, azurerm_role_assignment.role_assignment_storage, azurerm_role_assignment.role_assignment_event_hub]
   triggers = {
-    input_json                  = filemd5(data.archive_file.functions_zip.output_path)
+    # input_json                  = filemd5(data.archive_file.functions_zip.output_path)
+    publish_has                 = data.archive_file.functions_zip.output_base64sha256
     publish_code_command        = local.publish_code_command
     allow_public_access_command = local.allow_public_access_command
     deny_public_access_command  = local.deny_public_access_command

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,6 @@ variable "subscription_id" {
 
 variable "location" {
   description = "The location/region where the resources will be created."
-  default = "West Europe"
   type = string  
 }
 


### PR DESCRIPTION
original code fails to plan due to data  archive file block within functionapp module, the root terraform expects a zip file which does not exists unless it's successfully ran once, where replacing with the hash value works as hash exists without the actual file existing, and when apply is run the file will exist.

This PR fixes the above described issue.